### PR TITLE
Support dark mode based on user's preference

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from '@emotion/react';
-import { Box, createTheme, CssBaseline } from '@mui/material';
+import { Box, createTheme, CssBaseline, useMediaQuery } from '@mui/material';
 import ModalProvider from 'mui-modal-provider';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
@@ -7,10 +7,18 @@ import './App.scss';
 import Main from './components/Main';
 
 const App: React.FC = () => {
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+
+  const theme = createTheme({
+    palette: {
+      mode: prefersDarkMode ? 'dark' : 'light',
+    },
+  });
+
   return (
     <div className="App">
       <BrowserRouter basename={process.env.REACT_APP_BASENAME}>
-        <ThemeProvider theme={createTheme()}>
+        <ThemeProvider theme={theme}>
           <ModalProvider>
             <Box sx={{ display: 'flex' }}>
               <CssBaseline />


### PR DESCRIPTION
This commit supports dark mode according to #58.

[App.tsx](https://github.com/src-hyc/gitnoter/commit/7bcd2581e66225b88ea427fe5a1fdf30f948d398/src/App.tsx) is modified. It now queries user's preference of light/dark mode, and create a theme base on the preference.